### PR TITLE
Fixing the replacements order to remove phantom parenthesis

### DIFF
--- a/blueprints/R/The Real Housewives of Atlanta (2008)/0/blueprint.json
+++ b/blueprints/R/The Real Housewives of Atlanta (2008)/0/blueprint.json
@@ -27,14 +27,14 @@
         "Part Two",
         "Part Three",
         "Part Four",
-        "Part 1",
-        "Part 2",
-        "Part 3",
-        "Part 4",
         "(Part 1)",
         "(Part 2)",
         "(Part 3)",
-        "(Part 4)"
+        "(Part 4)",
+        "Part 1",
+        "Part 2",
+        "Part 3",
+        "Part 4"
       ],
       "replacements_out": [
         "I",

--- a/blueprints/R/The Real Housewives of Beverly Hills (2010)/0/blueprint.json
+++ b/blueprints/R/The Real Housewives of Beverly Hills (2010)/0/blueprint.json
@@ -27,14 +27,14 @@
         "Part Two",
         "Part Three",
         "Part Four",
-        "Part 1",
-        "Part 2",
-        "Part 3",
-        "Part 4",
         "(Part 1)",
         "(Part 2)",
         "(Part 3)",
-        "(Part 4)"
+        "(Part 4)",
+        "Part 1",
+        "Part 2",
+        "Part 3",
+        "Part 4"
       ],
       "replacements_out": [
         "I",

--- a/blueprints/R/The Real Housewives of Miami (2011)/0/blueprint.json
+++ b/blueprints/R/The Real Housewives of Miami (2011)/0/blueprint.json
@@ -27,14 +27,14 @@
         "Part Two",
         "Part Three",
         "Part Four",
-        "Part 1",
-        "Part 2",
-        "Part 3",
-        "Part 4",
         "(Part 1)",
         "(Part 2)",
         "(Part 3)",
-        "(Part 4)"
+        "(Part 4)",
+        "Part 1",
+        "Part 2",
+        "Part 3",
+        "Part 4"
       ],
       "replacements_out": [
         "I",


### PR DESCRIPTION
New contributions will have this fix already. Basically it was seeing "Part 1" before "(Part 1)" and leaving (I) which isn't the intention. 